### PR TITLE
BCO-14816-Groupless-Scaling

### DIFF
--- a/bigid/solutions/CloudNativeScanner/ecs-scaler-lambda/ecs_scaler_lambda.py
+++ b/bigid/solutions/CloudNativeScanner/ecs-scaler-lambda/ecs_scaler_lambda.py
@@ -107,6 +107,15 @@ def iterate_scanners(system_token, hostname, scanner_group):
         running.append(status.get("data")[0].get("running", 0))
     return any(running)
 
+def get_groupless_scans(system_token,hostname):
+    url = f"https://{hostname}/api/v1/scans/parent-scans"
+    headers = {"Authorization": system_token}
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        data = response.json()
+        scans = data.get("scanParents")
+        queued = [True for scan in scans if scan.get('progress', {}).get('state', '') == 'Queued']
+        return any(queued) 
 
 def main(
     refresh_token_secret_id,
@@ -121,11 +130,12 @@ def main(
     refresh_token = get_secret(refresh_token_secret_id, region_name)
     system_token = get_token(refresh_token, hostname)
     if system_token:
-        jobs = get_scans_jobs(hostname, system_token)
-        if not jobs:
-            return "No Jobs"
+        # jobs = get_scans_jobs(hostname, system_token)
+        # if not jobs:
+        #     return "No Jobs"
 
-        running = iterate_scanners(system_token, hostname, scanner_group)
+        # running = iterate_scanners(system_token, hostname, scanner_group)
+        running = get_groupless_scans(system_token, hostname)
         
         if not running:
             desired_count = minimum_desired_count

--- a/bigid/solutions/CloudNativeScanner/scanner.yaml
+++ b/bigid/solutions/CloudNativeScanner/scanner.yaml
@@ -103,8 +103,6 @@ Resources:
             - !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/bigid/bigid-scanner:${ImageTagVersion}"
             - !Sub "${ReplacementRepository}/bigid/bigid-scanner:${ImageTagVersion}"
           Environment:
-            - Name: BIGID_REFRESH_TOKEN
-              Value: '{{resolve:secretsmanager:bigid-scanner-token::::}}'
             - Name: BIGID_UI_HOST_EXT
               Value: !Sub "${BigIDHostname}"
             - Name: BIGID_UI_PORT_EXT
@@ -119,6 +117,9 @@ Resources:
               Value: !Sub "${ScannerGroupName}"
             - Name: RDS_SNAPSCAN_VPC_ID
               Value: !Ref VpcID
+          Secrets:
+            - Name: BIGID_REFRESH_TOKEN             
+              ValueFrom: !Ref RefreshTokenSecret
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/bigid/solutions/CloudNativeScanner/scanner.yaml
+++ b/bigid/solutions/CloudNativeScanner/scanner.yaml
@@ -306,6 +306,7 @@ Resources:
       Handler: ecs_scaler_lambda.lambda_handler
       Role: !GetAtt LambdaExecutionRole.Arn
       ReservedConcurrentExecutions: 1
+      Timeout: 30
       Code:
         S3Bucket: !Sub bigid-ecs-lambda-scaler-${AWS::Region}
         S3Key: ecs-scaler-lambda-v1.0.2.zip

--- a/bigid/solutions/CloudNativeScanner/scanner.yaml
+++ b/bigid/solutions/CloudNativeScanner/scanner.yaml
@@ -63,7 +63,7 @@ Parameters:
     Default: "3"
   MinimumScannerCount:
     Description: "The minimum number of BigID scanner instances (replicas) to run."
-    Type: String
+    Type: Number
     Default: "1"
   ScheduleExpression:
     Description: "The schedule expression for the scaling Lambda"
@@ -103,6 +103,8 @@ Resources:
             - !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/bigid/bigid-scanner:${ImageTagVersion}"
             - !Sub "${ReplacementRepository}/bigid/bigid-scanner:${ImageTagVersion}"
           Environment:
+            - Name: BIGID_REFRESH_TOKEN
+              Value: '{{resolve:secretsmanager:bigid-scanner-token::::}}'
             - Name: BIGID_UI_HOST_EXT
               Value: !Sub "${BigIDHostname}"
             - Name: BIGID_UI_PORT_EXT
@@ -117,9 +119,6 @@ Resources:
               Value: !Sub "${ScannerGroupName}"
             - Name: RDS_SNAPSCAN_VPC_ID
               Value: !Ref VpcID
-          Secrets:
-            - Name: BIGID_REFRESH_TOKEN             
-              ValueFrom: !Ref RefreshTokenSecret
           LogConfiguration:
             LogDriver: awslogs
             Options:


### PR DESCRIPTION
We're going to be utilizing, a rough draft essentially of being able to use a function called group less scans.

This will essentially pull from 'any of the queued scans' that are specified as part of the tenant, the full intention here is to scale the Task definition, whenever there is something in the queue, when the min_desired_count = 0 

So, essentially if there is something that is IN the queue, we will have the scanners scale.

However, we need to validate the scanner when it does SCAN it is receiving the job, and is able to properly action.

We'll be testing as part of staging. where we've deleted the current scanner / scaler / tiny scaler, etc which will be required to test the full capacity of going from 0 to maximum.